### PR TITLE
Fix errors caused by Firebase API change, and Short URL API deprecation

### DIFF
--- a/www/3d.html
+++ b/www/3d.html
@@ -90,7 +90,7 @@
     </div>
     <div id="example"></div>
 
-  <script src="//cdn.firebase.com/js/client/2.1.1/firebase.js"></script>
+  <script src="//www.gstatic.com/firebasejs/5.8.0/firebase.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/three.js/r70/three.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/screenfull.js/2.0.0/screenfull.min.js"></script>
   <script src="//wurfl.io/wurfl.js"></script>

--- a/www/index.html
+++ b/www/index.html
@@ -32,9 +32,10 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.12.1/ui-bootstrap-tpls.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/seedrandom/2.3.11/seedrandom.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/snap.svg/0.3.0/snap.svg-min.js"></script>
-  <script src="//cdn.firebase.com/js/client/2.0.4/firebase.js"></script>
-  <script src="//cdn.firebase.com/libs/angularfire/0.9.1/angularfire.min.js"></script>
+  <script src="//www.gstatic.com/firebasejs/5.8.0/firebase.js"></script>
+  <script src="//cdn.firebase.com/libs/angularfire/2.3.0/angularfire.min.js"></script>
   <script src="//wurfl.io/wurfl.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -142,7 +143,7 @@
               <div class="col-md-4 step-two">
                 <span class="num">2</span>
                 <p>Use your phone and open the URL or scan the QR code&nbsp;below.</p>
-                <a ng-hide="true" ng-href="3d.html#{{firebase_token}}" id="remote_link"></a>
+                <a ng-hide="true" ng-href="3d.html?u={{firebase_token}}" id="remote_link"></a>
                 <p>&nbsp;</p>
                 <a ng-href="{{short_remote_link}}">{{short_remote_link}}</a>
                 <p>&nbsp;</p>

--- a/www/js/config.js
+++ b/www/js/config.js
@@ -1,8 +1,11 @@
 var CONFIG = {
+  FIREBASE_APP_URL: 'https://MY_PROJECT.firebaseapp.com',
   // URL of your Firebase instance
-  FIREBASE_URL: 'https://MY_PROJECT.firebaseio.com/',
+  FIREBASE_DB_URL: 'https://MY_PROJECT.firebaseio.com/',
   // Public key for Google API
   GOOGLE_API_KEY: 'MY_KEY',
   // Analytics tracking ID (empty string to disable)
   GOOGLE_ANALYTICS_ID: '',
+  // Firebase Dynamic Links project, for short links
+  DYNAMIC_URL_BASE: 'https://MY_DYNAMIC_LINKS_PROJECT.page.link',
 };


### PR DESCRIPTION
Fix for https://github.com/googlevr/gvr-android-sdk/issues/598

**Problem**
As of a few weeks (to known), the official QR code generator for VR headsets on Google's site has not been working. It throws a javascript exception on typing any character in any of the form fields.

URL: https://vr.google.com/intl/en_in/cardboard/viewerprofilegenerator/

**Solution**
This pull request updates:
1. The Firebase library version from 2.0.4 to 5.8.0, and translates the changes in API (regarding auth) 
2. The AngularFire library version from 0.9.1 to 2.3.0, to be compatible with the new Firebase API
3. Switches from the deprecated Google URL Shortener API to the (recommended) Firebase Dynamic Links API

It has been tested successfully on my local system, with a different Android device accessing the shortlink generated.

**Updates required on Google's side**
Please enable [Firebase Dynamic Links](https://firebase.google.com/docs/dynamic-links/) on the Firebase Console (in the wwgc project), and create a Dynamic Links subdomain. This subdomain will need to be added to the config.js file.

I've accepted the CLA using the same username (cmdr2).

I hope this helps in bringing the QR code generator back online :) Please let me know if there are any code comments you'd like me to fix.

Thanks, and regards
~cmdr2